### PR TITLE
Fix JavaScript compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ Please file feature requests and bugs at the [issue tracker](https://github.com/
 ## Testing
 
 ```
-dart test test/crdt_test.dart test/hlc_test.dart test/map_crdt_test.dart
+dart test
 ```
 
 JavaScript version:
 ```
-dart test test/crdt_test.dart test/hlcjs_test.dart test/map_crdt_js_test.dart --platform node
+dart test --platform node
 ```

--- a/README.md
+++ b/README.md
@@ -45,3 +45,14 @@ A simple example is provided with this project, otherwise for a real-world appli
 ## Features and bugs
 
 Please file feature requests and bugs at the [issue tracker](https://github.com/cachapa/crdt/issues).
+
+## Testing
+
+```
+dart test test/crdt_test.dart test/hlc_test.dart test/map_crdt_test.dart
+```
+
+JavaScript version:
+```
+dart test test/crdt_test.dart test/hlcjs_test.dart test/map_crdt_js_test.dart --platform node
+```

--- a/lib/crdt.dart
+++ b/lib/crdt.dart
@@ -2,6 +2,6 @@ library crdt;
 
 export 'src/crdt.dart';
 export 'src/crdt_json.dart';
-export 'src/hlc.dart';
 export 'src/map_crdt.dart';
 export 'src/record.dart';
+export 'src/hlc.dart' if (dart.library.js) 'src/hlcjs.dart';

--- a/lib/src/bigint_max.dart
+++ b/lib/src/bigint_max.dart
@@ -1,0 +1,3 @@
+BigInt max(BigInt a, BigInt b) {
+  return a >= b ? a : b;
+}

--- a/lib/src/crdt.dart
+++ b/lib/src/crdt.dart
@@ -113,11 +113,11 @@ abstract class Crdt<K, V> {
   /// Should be overridden if the implementation can do it more efficiently.
   void refreshCanonicalTime() {
     final map = recordMap();
-    _canonicalTime = Hlc.fromLogicalTime(
-        map.isEmpty
-            ? 0
-            : map.values.map((record) => record.hlc.logicalTime).reduce(max),
-        nodeId);
+    _canonicalTime = map.isEmpty
+        ? Hlc.zero(nodeId)
+        : Hlc.fromLogicalTime(
+            map.values.map((record) => record.hlc.logicalTime).reduce(max),
+            nodeId);
   }
 
   /// Outputs the contents of this CRDT in Json format.

--- a/lib/src/crdt.dart
+++ b/lib/src/crdt.dart
@@ -1,7 +1,7 @@
 import 'dart:math';
 
 import 'crdt_json.dart';
-import 'hlc.dart';
+import 'hlc.dart' if (dart.library.js) 'hlcjs.dart';
 import 'record.dart';
 
 abstract class Crdt<K, V> {

--- a/lib/src/hlcjs.dart
+++ b/lib/src/hlcjs.dart
@@ -1,0 +1,167 @@
+export 'bigint_max.dart';
+
+import 'package:crdt/src/bigint_max.dart';
+
+const _shift = 16;
+BigInt _maxCounter = BigInt.from(0xFFFF);
+BigInt _maxDrift = BigInt.from(60000); // 1 minute in ms
+
+/// A Hybrid Logical Clock implementation.
+/// This class trades time precision for a guaranteed monotonically increasing
+/// clock in distributed systems.
+/// Inspiration: https://cse.buffalo.edu/tech-reports/2014-04.pdf
+///
+/// This is a JavaScript compatible version that uses BigInt.
+/// CRDTs use 64-bit integers but JavaScript integers are in the range of
+/// -(2^53 - 1)..(2^53 - 1) and bit operations are truncated to 32-bit.
+/// BigInt is able to handle full 64-bit range in JavaScript but are much less
+/// efficient.
+class Hlc<T> implements Comparable<Hlc> {
+  final BigInt millis;
+  final BigInt counter;
+  final T nodeId;
+
+  BigInt get logicalTime => (millis << _shift) + counter;
+
+  Hlc(BigInt millis, this.counter, this.nodeId)
+      : assert(counter <= _maxCounter),
+        assert(nodeId is Comparable),
+        assert(nodeId != null),
+        // Detect microseconds and convert to millis
+        millis = millis < BigInt.from(0x0001000000000000)
+            ? millis
+            : millis ~/ BigInt.from(1000);
+
+  Hlc.zero(T nodeId) : this(BigInt.zero, BigInt.zero, nodeId);
+
+  Hlc.fromDate(DateTime dateTime, T nodeId)
+      : this(BigInt.from(dateTime.millisecondsSinceEpoch), BigInt.zero, nodeId);
+
+  Hlc.now(T nodeId) : this.fromDate(DateTime.now(), nodeId);
+
+  Hlc.fromLogicalTime(BigInt logicalTime, T nodeId)
+      : this(logicalTime >> _shift, logicalTime & _maxCounter, nodeId);
+
+  factory Hlc.parse(String timestamp, [T Function(String value)? idDecoder]) {
+    final counterDash = timestamp.indexOf('-', timestamp.lastIndexOf(':'));
+    final nodeIdDash = timestamp.indexOf('-', counterDash + 1);
+    final millis = DateTime.parse(timestamp.substring(0, counterDash))
+        .millisecondsSinceEpoch;
+    final counter =
+        int.parse(timestamp.substring(counterDash + 1, nodeIdDash), radix: 16);
+    final nodeId = timestamp.substring(nodeIdDash + 1);
+    return Hlc(BigInt.from(millis), BigInt.from(counter),
+        idDecoder != null ? idDecoder(nodeId) : nodeId as T);
+  }
+
+  Hlc apply({BigInt? millis, BigInt? counter, T? nodeId}) => Hlc(
+      millis ?? this.millis, counter ?? this.counter, nodeId ?? this.nodeId);
+
+  /// Generates a unique, monotonic timestamp suitable for transmission to
+  /// another system in string format. Local wall time will be used if
+  /// [millis] isn't supplied.
+  factory Hlc.send(Hlc<T> canonical, {BigInt? millis}) {
+    // Retrieve the local wall time if millis is null
+    millis = millis ?? BigInt.from(DateTime.now().millisecondsSinceEpoch);
+
+    // Unpack the canonical time and counter
+    final millisOld = canonical.millis;
+    final counterOld = canonical.counter;
+
+    // Calculate the next time and counter
+    // * ensure that the logical time never goes backward
+    // * increment the counter if time does not advance
+    final millisNew = max(millisOld, millis);
+    final counterNew =
+        millisOld == millisNew ? counterOld + BigInt.one : BigInt.zero;
+
+    // Check the result for drift and counter overflow
+    if (millisNew - millis > _maxDrift) {
+      throw ClockDriftException(millisNew, millis);
+    }
+    if (counterNew > _maxCounter) {
+      throw OverflowException(counterNew.toInt());
+    }
+
+    return Hlc(millisNew, counterNew, canonical.nodeId);
+  }
+
+  /// Compares and validates a timestamp from a remote system with the local
+  /// canonical timestamp to preserve monotonicity.
+  /// Returns an updated canonical timestamp instance.
+  /// Local wall time will be used if [millis] isn't supplied.
+  factory Hlc.recv(Hlc<T> canonical, Hlc<T> remote, {BigInt? millis}) {
+    // Retrieve the local wall time if millis is null
+    millis = millis ?? BigInt.from(DateTime.now().millisecondsSinceEpoch);
+
+    // No need to do any more work if the remote logical time is lower
+    if (canonical.logicalTime >= remote.logicalTime) return canonical;
+
+    // Assert the node id
+    if (canonical.nodeId == remote.nodeId) {
+      throw DuplicateNodeException(canonical.nodeId.toString());
+    }
+    // Assert the remote clock drift
+    if (remote.millis - millis > _maxDrift) {
+      throw ClockDriftException(remote.millis, millis);
+    }
+
+    return Hlc<T>.fromLogicalTime(remote.logicalTime, canonical.nodeId);
+  }
+
+  String toJson() => toString();
+
+  @override
+  String toString() =>
+      '${DateTime.fromMillisecondsSinceEpoch(millis.toInt(), isUtc: true).toIso8601String()}'
+      '-${counter.toRadixString(16).toUpperCase().padLeft(4, '0')}'
+      '-$nodeId';
+
+  @override
+  int get hashCode => toString().hashCode;
+
+  @override
+  bool operator ==(other) => other is Hlc<T> && compareTo(other) == 0;
+
+  bool operator <(other) => other is Hlc<T> && compareTo(other) < 0;
+
+  bool operator <=(other) => this < other || this == other;
+
+  bool operator >(other) => other is Hlc<T> && compareTo(other) > 0;
+
+  bool operator >=(other) => this > other || this == other;
+
+  @override
+  int compareTo(Hlc other) {
+    final time = logicalTime.compareTo(other.logicalTime);
+    return time != 0 ? time : (nodeId as Comparable).compareTo(other.nodeId);
+  }
+}
+
+class ClockDriftException implements Exception {
+  final BigInt drift;
+
+  ClockDriftException(BigInt millisTs, BigInt millisWall)
+      : drift = millisTs - millisWall;
+
+  @override
+  String toString() => 'Clock drift of $drift ms exceeds maximum ($_maxDrift)';
+}
+
+class OverflowException implements Exception {
+  final int counter;
+
+  OverflowException(this.counter);
+
+  @override
+  String toString() => 'Timestamp counter overflow: $counter';
+}
+
+class DuplicateNodeException implements Exception {
+  final String nodeId;
+
+  DuplicateNodeException(this.nodeId);
+
+  @override
+  String toString() => 'Duplicate node: $nodeId';
+}

--- a/lib/src/map_crdt.dart
+++ b/lib/src/map_crdt.dart
@@ -41,8 +41,7 @@ class MapCrdt<K, V> extends Crdt<K, V> {
   @override
   Map<K, Record<V>> recordMap({Hlc? modifiedSince}) =>
       Map<K, Record<V>>.from(_map)
-        ..removeWhere((_, record) =>
-            record.modified.logicalTime < (modifiedSince?.logicalTime ?? 0));
+        ..removeWhere((_, record) => record.modified < modifiedSince);
 
   @override
   Stream<MapEntry<K, V?>> watch({K? key}) =>

--- a/lib/src/map_crdt.dart
+++ b/lib/src/map_crdt.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
 import 'crdt.dart';
-import 'hlc.dart';
+import 'hlc.dart' if (dart.library.js) 'hlcjs.dart';
 import 'record.dart';
 
 /// A CRDT backed by a in-memory map.

--- a/lib/src/record.dart
+++ b/lib/src/record.dart
@@ -1,4 +1,4 @@
-import 'hlc.dart';
+import 'hlc.dart' if (dart.library.js) 'hlcjs.dart';
 
 typedef KeyEncoder<K> = String Function(K key);
 typedef ValueEncoder<K, V> = dynamic Function(K key, V? value);

--- a/test/hlc_test.dart
+++ b/test/hlc_test.dart
@@ -1,3 +1,5 @@
+@TestOn('!js')
+
 import 'package:crdt/src/hlc.dart';
 import 'package:test/test.dart';
 

--- a/test/hlcjs_test.dart
+++ b/test/hlcjs_test.dart
@@ -1,3 +1,5 @@
+@TestOn('js')
+
 import 'package:crdt/src/hlcjs.dart';
 import 'package:test/test.dart';
 

--- a/test/hlcjs_test.dart
+++ b/test/hlcjs_test.dart
@@ -1,0 +1,262 @@
+import 'package:crdt/src/hlcjs.dart';
+import 'package:test/test.dart';
+
+BigInt _millis = BigInt.from(1000000000000);
+const _isoTime = '2001-09-09T01:46:40.000Z';
+BigInt _logicalTime = BigInt.parse('65536000000000066');
+
+void main() {
+  group('Constructors', () {
+    final hlc = Hlc(_millis, BigInt.from(0x42), 'abc');
+
+    test('default', () {
+      expect(hlc.millis, _millis);
+      expect(hlc.counter, BigInt.from(0x42));
+      expect(hlc.nodeId, 'abc');
+    });
+
+    test('default with microseconds', () {
+      expect(Hlc(_millis * BigInt.from(1000), BigInt.from(0x42), 'abc'), hlc);
+    });
+
+    test('zero', () {
+      expect(Hlc.zero('abc'),
+          hlc.apply(millis: BigInt.zero, counter: BigInt.zero));
+    });
+
+    test('from date', () {
+      expect(Hlc.fromDate(DateTime.parse(_isoTime), 'abc'),
+          hlc.apply(counter: BigInt.zero));
+    });
+
+    test('logical time', () {
+      expect(Hlc.fromLogicalTime(_logicalTime, 'abc'), hlc);
+    });
+
+    test('parse', () {
+      expect(Hlc<String>.parse('$_isoTime-0042-abc'), hlc);
+    });
+  });
+
+  group('String operations', () {
+    test('hlc to string', () {
+      final hlc = Hlc.parse('$_isoTime-0042-abc');
+      expect(hlc.toString(), '$_isoTime-0042-abc');
+    });
+
+    test('Parse hlc', () {
+      expect(Hlc<String>.parse('$_isoTime-0042-abc'),
+          Hlc(_millis, BigInt.from(0x42), 'abc'));
+    });
+  });
+
+  group('Non-String node id', () {
+    test('to hlc', () {
+      final hlc = Hlc<int>.parse('$_isoTime-0042-1', int.parse);
+      expect(hlc, Hlc(_millis, BigInt.from(0x42), 1));
+    });
+
+    test('to string', () {
+      final hlc = Hlc(_millis, BigInt.from(0x42), 1);
+      expect(hlc.toString(), '$_isoTime-0042-1');
+    });
+  });
+
+  group('Comparison', () {
+    test('Equality', () {
+      final hlc1 = Hlc.parse('$_isoTime-0042-abc');
+      final hlc2 = Hlc.parse('$_isoTime-0042-abc');
+      expect(hlc1, hlc2);
+      expect(hlc1 <= hlc2, isTrue);
+      expect(hlc1 >= hlc2, isTrue);
+    });
+
+    test('Different node ids', () {
+      final hlc1 = Hlc.parse('$_isoTime-0042-abc');
+      final hlc2 = Hlc.parse('$_isoTime-0042-abcd');
+      expect(hlc1, isNot(hlc2));
+    });
+
+    test('Less than millis', () {
+      final hlc1 = Hlc(_millis, BigInt.from(0x42), 'abc');
+      final hlc2 = Hlc(_millis + BigInt.one, BigInt.zero, 'abc');
+      expect(hlc1 < hlc2, isTrue);
+      expect(hlc1 <= hlc2, isTrue);
+    });
+
+    test('Less than counter', () {
+      final hlc1 = Hlc.parse('$_isoTime-0042-abc');
+      final hlc2 = Hlc.parse('$_isoTime-0043-abc');
+      expect(hlc1 < hlc2, isTrue);
+      expect(hlc1 <= hlc2, isTrue);
+    });
+
+    test('Less than node id', () {
+      final hlc1 = Hlc.parse('$_isoTime-0042-abc');
+      final hlc2 = Hlc.parse('$_isoTime-0042-abb');
+      expect(hlc1 > hlc2, isTrue);
+      expect(hlc1 >= hlc2, isTrue);
+    });
+
+    test('Fail less than if equals', () {
+      final hlc1 = Hlc.parse('$_isoTime-0042-abc');
+      final hlc2 = Hlc.parse('$_isoTime-0042-abc');
+      expect(hlc1 < hlc2, isFalse);
+    });
+
+    test('Fail less than if millis and counter disagree', () {
+      final hlc1 = Hlc(_millis + BigInt.one, BigInt.zero, 'abc');
+      final hlc2 = Hlc(_millis, BigInt.from(0x42), 'abc');
+      expect(hlc1 < hlc2, isFalse);
+    });
+
+    test('More than millis', () {
+      final hlc1 = Hlc(_millis + BigInt.one, BigInt.from(0x42), 'abc');
+      final hlc2 = Hlc(_millis, BigInt.zero, 'abc');
+      expect(hlc1 > hlc2, isTrue);
+      expect(hlc1 >= hlc2, isTrue);
+    });
+
+    test('More than counter', () {
+      final hlc1 = Hlc(_millis + BigInt.one, BigInt.from(0x42), 'abc');
+      final hlc2 = Hlc(_millis, BigInt.zero, 'abc');
+      expect(hlc1 > hlc2, isTrue);
+      expect(hlc1 >= hlc2, isTrue);
+    });
+
+    test('More than node id', () {
+      final hlc1 = Hlc(_millis, BigInt.from(0x42), 'abc');
+      final hlc2 = Hlc(_millis, BigInt.from(0x42), 'abb');
+      expect(hlc1 > hlc2, isTrue);
+      expect(hlc1 >= hlc2, isTrue);
+    });
+
+    test('Compare', () {
+      final hlc = Hlc(_millis, BigInt.from(0x42), 'abc');
+      expect(hlc.compareTo(Hlc(_millis, BigInt.from(0x42), 'abc')), 0);
+
+      expect(
+          hlc.compareTo(Hlc(_millis + BigInt.one, BigInt.from(0x42), 'abc')) <
+              0,
+          isTrue);
+      expect(hlc.compareTo(Hlc(_millis, BigInt.from(0x43), 'abc')) < 0, isTrue);
+      expect(hlc.compareTo(Hlc(_millis, BigInt.from(0x42), 'abd')) < 0, isTrue);
+
+      expect(
+          hlc.compareTo(Hlc(_millis - BigInt.one, BigInt.from(0x42), 'abc')) >
+              0,
+          isTrue);
+      expect(hlc.compareTo(Hlc(_millis, BigInt.from(0x41), 'abc')) > 0, isTrue);
+      expect(hlc.compareTo(Hlc(_millis, BigInt.from(0x42), 'abb')) > 0, isTrue);
+    });
+  });
+
+  group('Logical time representation', () {
+    test('Logical time stability', () {
+      final hlc = Hlc.fromLogicalTime(_logicalTime, 'abc');
+      expect(hlc.logicalTime, _logicalTime);
+    });
+
+    test('Hlc as logical time', () {
+      final hlc = Hlc.parse('$_isoTime-0042-abc');
+      expect(hlc.logicalTime, _logicalTime);
+    });
+
+    test('Hlc from logical time', () {
+      final hlc = Hlc.parse('$_isoTime-0042-abc');
+      expect(Hlc.fromLogicalTime(_logicalTime, 'abc'), hlc);
+    });
+  });
+
+  group('Send', () {
+    test('Higher canonical time', () {
+      final hlc = Hlc(_millis + BigInt.one, BigInt.from(0x42), 'abc');
+      final sendHlc = Hlc.send(hlc, millis: _millis);
+      expect(sendHlc, isNot(hlc));
+      expect(sendHlc.millis, hlc.millis);
+      expect(sendHlc.counter, BigInt.from(0x43));
+      expect(sendHlc.nodeId, hlc.nodeId);
+    });
+
+    test('Equal canonical time', () {
+      final hlc = Hlc(_millis, BigInt.from(0x42), 'abc');
+      final sendHlc = Hlc.send(hlc, millis: _millis);
+      expect(sendHlc, isNot(hlc));
+      expect(sendHlc.millis, _millis);
+      expect(sendHlc.counter, BigInt.from(0x43));
+      expect(sendHlc.nodeId, hlc.nodeId);
+    });
+
+    test('Lower canonical time', () {
+      final hlc = Hlc(_millis - BigInt.one, BigInt.from(0x42), 'abc');
+      final sendHlc = Hlc.send(hlc, millis: _millis);
+      expect(sendHlc, isNot(hlc));
+      expect(sendHlc.millis, _millis);
+      expect(sendHlc.counter, BigInt.zero);
+      expect(sendHlc.nodeId, hlc.nodeId);
+    });
+
+    test('Fail on clock drift', () {
+      final hlc = Hlc(_millis + BigInt.from(60001), BigInt.zero, 'abc');
+      expect(() => Hlc.send(hlc, millis: _millis),
+          throwsA(isA<ClockDriftException>()));
+    });
+
+    test('Fail on counter overflow', () {
+      final hlc = Hlc(_millis, BigInt.from(0xFFFF), 'abc');
+      expect(() => Hlc.send(hlc, millis: _millis),
+          throwsA(isA<OverflowException>()));
+    });
+  });
+
+  group('Receive', () {
+    final canonical = Hlc.parse('$_isoTime-0042-abc');
+
+    test('Higher canonical time', () {
+      final remote = Hlc(_millis - BigInt.one, BigInt.from(0x42), 'abcd');
+      final hlc = Hlc.recv(canonical, remote, millis: _millis);
+      expect(hlc, equals(canonical));
+    });
+
+    test('Same remote time', () {
+      final remote = Hlc(_millis, BigInt.from(0x42), 'abcd');
+      final hlc = Hlc.recv(canonical, remote, millis: _millis);
+      expect(hlc, Hlc(remote.millis, remote.counter, canonical.nodeId));
+    });
+
+    test('Higher remote time', () {
+      final remote = Hlc(_millis + BigInt.one, BigInt.zero, 'abcd');
+      final hlc = Hlc.recv(canonical, remote, millis: _millis);
+      expect(hlc, Hlc(remote.millis, remote.counter, canonical.nodeId));
+    });
+
+    test('Higher wall clock time', () {
+      final remote = Hlc.parse('$_isoTime-0000-abcd');
+      final hlc = Hlc.recv(canonical, remote, millis: _millis + BigInt.one);
+      expect(hlc, canonical);
+    });
+
+    test('Skip node id check if time is lower', () {
+      final remote = Hlc(_millis - BigInt.one, BigInt.from(0x42), 'abc');
+      expect(Hlc.recv(canonical, remote, millis: _millis), canonical);
+    });
+
+    test('Skip node id check if time is same', () {
+      final remote = Hlc(_millis, BigInt.from(0x42), 'abc');
+      expect(Hlc.recv(canonical, remote, millis: _millis), canonical);
+    });
+
+    test('Fail on node id', () {
+      final remote = Hlc(_millis + BigInt.one, BigInt.zero, 'abc');
+      expect(() => Hlc.recv(canonical, remote, millis: _millis),
+          throwsA(isA<DuplicateNodeException>()));
+    });
+
+    test('Fail on clock drift', () {
+      final remote =
+          Hlc(_millis + BigInt.from(60001), BigInt.from(0x42), 'abcd');
+      expect(() => Hlc.recv(canonical, remote, millis: _millis),
+          throwsA(isA<ClockDriftException>()));
+    });
+  });
+}

--- a/test/map_crdt_js_test.dart
+++ b/test/map_crdt_js_test.dart
@@ -1,3 +1,5 @@
+@TestOn('js')
+
 import 'package:crdt/crdt.dart';
 import 'package:test/test.dart';
 

--- a/test/map_crdt_js_test.dart
+++ b/test/map_crdt_js_test.dart
@@ -1,0 +1,304 @@
+import 'package:crdt/crdt.dart';
+import 'package:test/test.dart';
+
+import 'crdt_test.dart';
+
+BigInt _millis = BigInt.from(1000000000000);
+const _isoTime = '2001-09-09T01:46:40.000Z';
+
+void main() {
+  final hlcNow = Hlc.now('abc');
+
+  crdtTests<MapCrdt<String, int>>('abc', syncSetup: () => MapCrdt('abc'));
+
+  group('Seed', () {
+    late Crdt crdt;
+
+    setUp(() {
+      crdt = MapCrdt('abc', {'x': Record(hlcNow, 1, hlcNow)});
+    });
+
+    test('Seed item', () {
+      expect(crdt.get('x'), 1);
+    });
+
+    test('Seed and put', () {
+      crdt.put('x', 2);
+      expect(crdt.get('x'), 2);
+    });
+  });
+
+  group('Merge', () {
+    late Crdt<String, int> crdt;
+
+    setUp(() {
+      crdt = MapCrdt('abc');
+    });
+
+    test('Merge older', () {
+      crdt.put('x', 2);
+      crdt.merge({
+        'x': Record(Hlc(_millis - BigInt.one, BigInt.zero, 'xyz'), 1, hlcNow)
+      });
+      expect(crdt.get('x'), 2);
+    });
+
+    test('Merge very old', () {
+      crdt.put('x', 2);
+      crdt.merge(
+          {'x': Record(Hlc(BigInt.zero, BigInt.zero, 'xyz'), 1, hlcNow)});
+      expect(crdt.get('x'), 2);
+    });
+
+    test('Merge newer', () async {
+      crdt.put('x', 1);
+      await Future.delayed(Duration(milliseconds: 1));
+      crdt.merge({'x': Record(Hlc.now('xyz'), 2, hlcNow)});
+      expect(crdt.get('x'), 2);
+    });
+
+    test('Disambiguate using node id', () {
+      crdt.merge({'x': Record(Hlc(_millis, BigInt.zero, 'nodeA'), 1, hlcNow)});
+      crdt.merge({'x': Record(Hlc(_millis, BigInt.zero, 'nodeB'), 2, hlcNow)});
+      expect(crdt.get('x'), 2);
+    });
+
+    test('Merge same', () {
+      crdt.put('x', 2);
+      final remoteTs = crdt.getRecord('x')!.hlc;
+      crdt.merge({'x': Record(remoteTs, 1, hlcNow)});
+      expect(crdt.get('x'), 2);
+    });
+
+    test('Merge older, newer counter', () {
+      crdt.put('x', 2);
+      crdt.merge({
+        'x': Record(Hlc(_millis - BigInt.one, BigInt.two, 'xyz'), 1, hlcNow)
+      });
+      expect(crdt.get('x'), 2);
+    });
+
+    test('Merge same, newer counter', () {
+      crdt.put('x', 1);
+      final remoteTs = Hlc(crdt.getRecord('x')!.hlc.millis, BigInt.two, 'xyz');
+      crdt.merge({'x': Record(remoteTs, 2, hlcNow)});
+      expect(crdt.get('x'), 2);
+    });
+
+    test('Merge new item', () {
+      final map = {'x': Record<int>(Hlc.now('xyz'), 2, hlcNow)};
+      crdt.merge(map);
+      expect(crdt.recordMap(), map);
+    });
+
+    test('Merge deleted item', () async {
+      crdt.put('x', 1);
+      await Future.delayed(Duration(milliseconds: 1));
+      crdt.merge({'x': Record(Hlc.now('xyz'), null, hlcNow)});
+      expect(crdt.isDeleted('x'), isTrue);
+    });
+
+    test('Update HLC on merge', () {
+      crdt.put('x', 1);
+      crdt.merge({
+        'y': Record(Hlc(_millis - BigInt.one, BigInt.zero, 'xyz'), 2, hlcNow)
+      });
+      expect(crdt.values, [1, 2]);
+    });
+  });
+
+  group('Serialization', () {
+    test('To map', () {
+      final crdt = MapCrdt('abc', {
+        'x': Record<int>(Hlc(_millis, BigInt.zero, 'abc'), 1, hlcNow),
+      });
+      expect(crdt.recordMap(),
+          {'x': Record<int>(Hlc(_millis, BigInt.zero, 'abc'), 1, hlcNow)});
+    });
+
+    test('jsonEncodeStringKey', () {
+      final crdt = MapCrdt<String, int>('abc', {
+        'x': Record(Hlc(_millis, BigInt.zero, 'abc'), 1, hlcNow),
+      });
+      expect(crdt.toJson(), '{"x":{"hlc":"$_isoTime-0000-abc","value":1}}');
+    });
+
+    test('jsonEncodeIntKey', () {
+      final crdt = MapCrdt<int, int>('abc', {
+        1: Record(Hlc(_millis, BigInt.zero, 'abc'), 1, hlcNow),
+      });
+      expect(crdt.toJson(), '{"1":{"hlc":"$_isoTime-0000-abc","value":1}}');
+    });
+
+    test('jsonEncodeDateTimeKey', () {
+      final crdt = MapCrdt<DateTime, int>('abc', {
+        DateTime(2000, 01, 01, 01, 20):
+            Record(Hlc(_millis, BigInt.zero, 'abc'), 1, hlcNow),
+      });
+      expect(crdt.toJson(),
+          '{"2000-01-01 01:20:00.000":{"hlc":"$_isoTime-0000-abc","value":1}}');
+    });
+
+    test('jsonEncodeCustomClassValue', () {
+      final crdt = MapCrdt<String, TestClass>('abc', {
+        'x':
+            Record(Hlc(_millis, BigInt.zero, 'abc'), TestClass('test'), hlcNow),
+      });
+      expect(crdt.toJson(),
+          '{"x":{"hlc":"$_isoTime-0000-abc","value":{"test":"test"}}}');
+    });
+
+    test('jsonEncodeCustomNodeId', () {
+      final crdt = MapCrdt<String, int>('abc', {
+        'x': Record(Hlc<int>(_millis, BigInt.zero, 1), 0, hlcNow),
+      });
+      expect(crdt.toJson(), '{"x":{"hlc":"$_isoTime-0000-1","value":0}}');
+    });
+
+    test('jsonDecodeStringKey', () {
+      final crdt = MapCrdt<String, int>('abc');
+      final map = CrdtJson.decode<String, int>(
+          '{"x":{"hlc":"$_isoTime-0000-abc","value":1}}', hlcNow);
+      crdt.putRecords(map);
+      expect(crdt.recordMap(),
+          {'x': Record<int>(Hlc(_millis, BigInt.zero, 'abc'), 1, hlcNow)});
+    });
+
+    test('jsonDecodeIntKey', () {
+      final crdt = MapCrdt<int, int>('abc');
+      final map = CrdtJson.decode<int, int>(
+          '{"1":{"hlc":"$_isoTime-0000-abc","value":1}}', hlcNow,
+          keyDecoder: (key) => int.parse(key));
+      crdt.putRecords(map);
+      expect(crdt.recordMap(),
+          {1: Record(Hlc(_millis, BigInt.zero, 'abc'), 1, hlcNow)});
+    });
+
+    test('jsonDecodeDateTimeKey', () {
+      final crdt = MapCrdt<DateTime, int>('abc');
+      final map = CrdtJson.decode<DateTime, int>(
+          '{"2000-01-01 01:20:00.000":{"hlc":"$_isoTime-0000-abc","value":1}}',
+          hlcNow,
+          keyDecoder: (key) => DateTime.parse(key));
+      crdt.putRecords(map);
+      expect(crdt.recordMap(), {
+        DateTime(2000, 01, 01, 01, 20):
+            Record(Hlc(_millis, BigInt.zero, 'abc'), 1, hlcNow)
+      });
+    });
+
+    test('jsonDecodeCustomClassValue', () {
+      final crdt = MapCrdt<String, TestClass>('abc');
+      final map = CrdtJson.decode<String, TestClass>(
+          '{"x":{"hlc":"$_isoTime-0000-abc","value":{"test":"test"}}}', hlcNow,
+          valueDecoder: (key, value) => TestClass.fromJson(value));
+      crdt.putRecords(map);
+      expect(crdt.recordMap(), {
+        'x': Record(Hlc(_millis, BigInt.zero, 'abc'), TestClass('test'), hlcNow)
+      });
+    });
+
+    test('jsonDecodeCustomNodeId', () {
+      final crdt = MapCrdt<String, int>('abc');
+      final map = CrdtJson.decode<String, int>(
+          '{"x":{"hlc":"$_isoTime-0000-1","value":0}}', hlcNow,
+          nodeIdDecoder: int.parse);
+      crdt.putRecords(map);
+      expect(crdt.recordMap(),
+          {'x': Record(Hlc(_millis, BigInt.zero, 1), 0, hlcNow)});
+    });
+  });
+
+  group('Delta subsets', () {
+    late Crdt crdt;
+    final hlc1 = Hlc(_millis, BigInt.zero, 'abc');
+    final hlc2 = Hlc(_millis + BigInt.one, BigInt.zero, 'abc');
+    final hlc3 = Hlc(_millis + BigInt.two, BigInt.zero, 'abc');
+
+    setUp(() {
+      crdt = MapCrdt('abc', {
+        'x': Record(hlc1, 1, hlc1),
+        'y': Record(hlc2, 2, hlc2),
+      });
+    });
+
+    test('null modifiedSince', () {
+      final map = crdt.recordMap();
+      expect(map.length, 2);
+    });
+
+    test('modifiedSince hlc1', () {
+      final map = crdt.recordMap(modifiedSince: hlc1);
+      expect(map.length, 2);
+    });
+
+    test('modifiedSince hlc2', () {
+      final map = crdt.recordMap(modifiedSince: hlc2);
+      expect(map.length, 1);
+    });
+
+    test('modifiedSince hlc3', () {
+      final map = crdt.recordMap(modifiedSince: hlc3);
+      expect(map.length, 0);
+    });
+  });
+
+  group('Delta sync', () {
+    late Crdt crdtA;
+    late Crdt crdtB;
+    late Crdt crdtC;
+
+    setUp(() async {
+      crdtA = MapCrdt('a');
+      crdtB = MapCrdt('b');
+      crdtC = MapCrdt('c');
+
+      crdtA.put('x', 1);
+      await Future.delayed(Duration(milliseconds: 100));
+      crdtB.put('x', 2);
+    });
+
+    test('Merge in order', () {
+      _sync(crdtA, crdtC);
+      _sync(crdtB, crdtC);
+
+      expect(crdtA.get('x'), 1); // node A still contains the old value
+      expect(crdtB.get('x'), 2);
+      expect(crdtC.get('x'), 2);
+    });
+
+    test('Merge in reverse order', () {
+      _sync(crdtB, crdtC);
+      _sync(crdtA, crdtC);
+      _sync(crdtB, crdtC);
+
+      expect(crdtA.get('x'), 2);
+      expect(crdtB.get('x'), 2);
+      expect(crdtC.get('x'), 2);
+    });
+  });
+}
+
+void _sync(Crdt local, Crdt remote) {
+  final time = local.canonicalTime;
+  final l = local.recordMap();
+  remote.merge(l);
+  final r = remote.recordMap(modifiedSince: time);
+  local.merge(r);
+}
+
+class TestClass {
+  final String test;
+
+  TestClass(this.test);
+
+  static TestClass fromJson(dynamic map) => TestClass(map['test']);
+
+  Map<String, dynamic> toJson() => {'test': test};
+
+  @override
+  bool operator ==(other) => other is TestClass && test == other.test;
+
+  @override
+  String toString() => test;
+}

--- a/test/map_crdt_test.dart
+++ b/test/map_crdt_test.dart
@@ -1,3 +1,5 @@
+@TestOn('!js')
+
 import 'dart:io';
 
 import 'package:crdt/crdt.dart';


### PR DESCRIPTION
HLC requires bit operations on 64-bit numbers but bit operations in JavaScript are limited to 32 bit ([source: Numbers in Dart](https://dart.dev/guides/language/numbers)) which causes incorrect behavior of the HLC.

This PR uses BigInt if used in JavaScript which fixes the issue but results in less efficient code. The original implementation is used if not in JS.

This PR will break hive_crdt if that is used in Web, although the original behavior is incorrect anyway.
A fix for hive_crdt is as simple as [here](https://github.com/teemu-kemppainen/hive_crdt/commit/c92a28771e17707866f7884e39e639a835647b45#diff-bcea47b2823f02a632b322dbdc42dc4a83d04870b0b5eb1b795dbb26d9360aec) if used with these changes.